### PR TITLE
Ee/add typescript paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tailwindcss": "^4.1.4",
     "typescript": "^5.7.3",
     "vite": "^6.3.0",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       vite:
         specifier: ^6.3.0
         version: 6.3.0(jiti@2.4.2)(lightningcss@1.29.2)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2))
       vitest:
         specifier: ^3.1.1
         version: 3.1.1(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)
@@ -1152,6 +1155,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1639,6 +1645,16 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  tsconfck@3.1.5:
+    resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1661,6 +1677,14 @@ packages:
     resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@6.3.0:
     resolution: {integrity: sha512-9aC0n4pr6hIbvi1YOpFjwQ+QOTGssvbJKoeYkuHHGWwlXfdxQlI8L2qNMo9awEEcCPSiS+5mJZk5jH1PAqoDeQ==}
@@ -2806,6 +2830,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  globrex@0.1.2: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -3223,6 +3249,10 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  tsconfck@3.1.5(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -3259,6 +3289,17 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2)):
+    dependencies:
+      debug: 4.4.0
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@5.8.3)
+    optionalDependencies:
+      vite: 6.3.0(jiti@2.4.2)(lightningcss@1.29.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:

--- a/src/features/bank/BankState.ts
+++ b/src/features/bank/BankState.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "../../types/transaction";
+import { Transaction } from "@/types/transaction";
 import { BankStorage } from "./BankStorage";
 import { createDepositCommand } from "./commands/deposit";
 import { createPrintCommand } from "./commands/print";

--- a/src/features/bank/commands/deposit.test.ts
+++ b/src/features/bank/commands/deposit.test.ts
@@ -1,6 +1,6 @@
+import { BankState } from "@/features/bank/BankState";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "../../../test/matchers";
-import { BankState } from "../BankState";
 import { MAX_DEPOSIT_AMOUNT } from "../utils";
 import { createDepositCommand } from "./deposit";
 

--- a/src/features/bank/commands/deposit.test.ts
+++ b/src/features/bank/commands/deposit.test.ts
@@ -1,6 +1,5 @@
 import { BankState } from "@/features/bank/BankState";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import "../../../test/matchers";
 import { MAX_DEPOSIT_AMOUNT } from "../utils";
 import { createDepositCommand } from "./deposit";
 

--- a/src/features/bank/commands/print.test.ts
+++ b/src/features/bank/commands/print.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import "../../../test/matchers";
 import { Transaction } from "../../../types/transaction";
 import { BankState } from "../BankState";
 import { createPrintCommand } from "./print";

--- a/src/features/bank/commands/reset.test.ts
+++ b/src/features/bank/commands/reset.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import "../../../test/matchers";
 import { BankState } from "../BankState";
 import { createResetCommand } from "./reset";
 

--- a/src/features/bank/commands/withdraw.test.ts
+++ b/src/features/bank/commands/withdraw.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import "../../../test/matchers";
 import { BankState } from "../BankState";
 import { BankStorage } from "../BankStorage";
 import { createWithdrawCommand } from "./withdraw";

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "./matchers";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,13 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-
+import tsConfigPaths from "vite-tsconfig-paths";
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), tsConfigPaths()],
+  resolve: {
+    alias: {
+      "@": "/src",
+    },
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: [],
+    setupFiles: ["src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{js,ts,jsx,tsx}"],
     exclude: ["tests/**/*"],
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
 import react from "@vitejs/plugin-react";
+import tsConfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsConfigPaths()],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Changes

- Added Typescript path alias for dev ergonomics. https://dev.to/naucode/path-aliases-in-typescript-and-why-you-should-use-them-2odf
- Create a `setup.ts` file, add`matchers` to that. We added custom Vitest matchers, but we want that to be included in every test that we have.

Why we need path alias:

| Without Alias | With Alias |
| :-- | :-- |
| `import { User } from '../../user/model'` | `import { User } from '@modules/user/model'` |
| `import { Cache } from '../../../../cache'` | `import { Cache } from '@services/cache'` |